### PR TITLE
Allows GNOME users to browse photos on network shares

### DIFF
--- a/org.nomacs.ImageLounge.json
+++ b/org.nomacs.ImageLounge.json
@@ -10,7 +10,8 @@
         "--socket=wayland",
         "--socket=pulseaudio",
         "--filesystem=home",
-        "--filesystem=/media"
+        "--filesystem=/media",
+        "--filesystem=xdg-run/gvfs"
     ],
     "command": "nomacs",
     "cleanup": [

--- a/org.nomacs.ImageLounge.json
+++ b/org.nomacs.ImageLounge.json
@@ -31,7 +31,7 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://www.exiv2.org/builds/exiv2-0.27.5-Source.tar.gz",
+                    "url": "https://github.com/Exiv2/exiv2/releases/download/v0.27.5/exiv2-0.27.5-Source.tar.gz",
                     "sha256": "35a58618ab236a901ca4928b0ad8b31007ebdc0386d904409d825024e45ea6e2"
                 }
             ]


### PR DESCRIPTION
When using Nomacs on GNOME, you are able to open file from network share, but you won't be able to browse photos within the Nomacs.
To xdg-run/gvfs are mounted SAMBA shares, FTP shares, Google drive, etc..